### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/web-api/CHANGELOG.md
+++ b/web-api/CHANGELOG.md
@@ -9,7 +9,7 @@ Our specifications are programmatically generated from a collection of internal 
 * Brought OpenAPI 2.0 specification up to date with most of our internal metadata and JSON schema systems.
     - Because OpenAPI 2.0 uses a _subset_ (and sometimes a _superset_) of JSON Schema, some schema definitions are modified in translation and not as expressive as reality. In particular, expressing the `oneOf` instruction is difficult and we replace this nuance with the generic `items`.
     - Many of our schemas are improved and no longer require copious use of `additionalProperties` to be described.
-* Removed [`rtm.start`](https://api.slack.com/methods/rtm.start) from the method catalog. Its response varies and we strongly recommend developers to use [`rtm.connect`](https://api.slack.com/methods/rtm.start) instead.
+* Removed [`rtm.start`](https://api.slack.com/methods/rtm.start) from the method catalog. Its response varies and we strongly recommend developers to use [`rtm.connect`](https://api.slack.com/methods/rtm.connect) instead.
 * Removed some of the `search.*` methods from the catalog due to varied responses that cannot yet pass validation. We'll add these back in the next release.
 * Added a bare bones `definitions/blocks` schema. We'd like to provide finer grained schema for [Block Kit](https://api.slack.com/block-kit) in the future.
 * 132 methods now have well-defined response schema.


### PR DESCRIPTION
rtm.connect is redirecting to rtm.start

###  Submitting a PR

Our open Web API specification is an artifact. It's the end result of an incredible machine (well, a Python script) compiling all the facts, fibs, schemas, and articulated examples across hundreds of individual files that describe our platform internally.

As such, we cannot accept pull requests on these spec files. Please file an Issue if you have questions, suggestions or feedback.
